### PR TITLE
Update amazon.py

### DIFF
--- a/src/scraper/amazon.py
+++ b/src/scraper/amazon.py
@@ -14,9 +14,9 @@ class AmazonScrapeResult(ScrapeResult):
             self.logger.warning(f'missing title: {self.url}')
 
         # get listed price
-        tag = self.soup.body.select_one('div.a-section > span#price_inside_buybox')
+        tag = self.soup.body.select_one('div.a-section > span#aod-price-1')
         if not tag:
-            tag = self.soup.body.select_one('div#price span#priceblock_ourprice')
+            tag = self.soup.body.select_one('div.a-section > span#aod-price-0')
         price_str = self.set_price(tag)
         if price_str:
             alert_subject = f'In Stock for {price_str}'


### PR DESCRIPTION
SEE ALL BUYING OPTION - AMAZON

I am monitoring the amazon website since few months already.
The product who become available (amazon retail) Pop first in the SEE ALL BUYING OPTION for x reason.

you can have access to this menu when you add "#aod" at the end of the amazon link you entered in (config/Amazon_rtx_....)

Exemple :

https://www.amazon.com/PULSE-3D-Wireless-Headset-PlayStation-5/dp/B08FC6QLKN#aod

The main idea is to monitor the price of the 2 first listing in the SEE ALL BUYING OPTION (it where it pop all the time)

Here is the price to check:


div#aod-price-0.a-section a-spacing-none a-padding-none
div#aod-price-1.a-section a-spacing-none a-padding-none

why monitoring the price change in see all buying option and not the Add to cart button?  amazon allow third part seller on their platform so you can have in stock alert when its not retail , and most of the time, the product is sold out before being available on the main page.

if we can modify this, it would be perfect!!

I am using distill extension and this technique works 100% for me,
its actually the only one option to have a chance to catch a GPU from amazon

i didn't test the modified script but here is an idea of it.

Thanks,

i will need help to finalize it ! 
